### PR TITLE
Windows fixes

### DIFF
--- a/cappy/cappy.py
+++ b/cappy/cappy.py
@@ -67,7 +67,7 @@ def split_path(path):
 
 
 def get_hashed_filepath(stub, method, parsed_url, params):
-    hash_template = '{method}:{stub}{param_str}'
+    hash_template = '{method}%s{stub}{param_str}' % os.sep
     param_str = ''
     if not stub:
         stub = 'index.html'

--- a/cappy/cappy.py
+++ b/cappy/cappy.py
@@ -56,10 +56,10 @@ def split_path(path):
         last_fragment = split_path[-1]
         if '.' not in last_fragment:
             filename = ''
-            dirname = os.sep.join(split_path)
+            dirname = os.path.join(*split_path)
         else:
             filename = last_fragment
-            dirname = os.sep.join(split_path[:-1])
+            dirname = os.path.join(*split_path[:-1])
     else:
         filename = ''
         dirname = path

--- a/cappy/cappy.py
+++ b/cappy/cappy.py
@@ -19,6 +19,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
+from hashlib import md5
 
 def log(*args):
     message = "".join(args)
@@ -67,7 +68,6 @@ def split_path(path):
 
 
 def get_hashed_filepath(stub, method, parsed_url, params):
-    hash_template = '{method}%s{stub}{param_str}' % os.sep
     param_str = ''
     if not stub:
         stub = 'index.html'
@@ -77,7 +77,7 @@ def get_hashed_filepath(stub, method, parsed_url, params):
         param_str = parsed_url.query
     if param_str:
         param_str = '?'+param_str
-    return hash_template.format(method=method, stub=stub, param_str=param_str)
+    return md5(method + stub + param_str).hexdigest()
 
 
 class CacheHandler(SocketServer.ThreadingMixIn, BaseHTTPServer.BaseHTTPRequestHandler):

--- a/cappy/cappy.py
+++ b/cappy/cappy.py
@@ -56,10 +56,10 @@ def split_path(path):
         last_fragment = split_path[-1]
         if '.' not in last_fragment:
             filename = ''
-            dirname = path
+            dirname = os.sep.join(split_path)
         else:
             filename = last_fragment
-            dirname = '/'.join(split_path[:-1])
+            dirname = os.sep.join(split_path[:-1])
     else:
         filename = ''
         dirname = path

--- a/cappy/cappy.py
+++ b/cappy/cappy.py
@@ -113,7 +113,7 @@ class CacheHandler(SocketServer.ThreadingMixIn, BaseHTTPServer.BaseHTTPRequestHa
             log("Cache miss")
             data = self.make_request(url=url, params=params, method=method)
             # make dirs before you write to file
-            dirname, _filename = split_path(cache_file)
+            dirname = os.path.dirname(cache_file)
             make_dirs(dirname)
             file_obj = fopen(cache_file, 'wb+')
             file_obj.writelines(data)


### PR DESCRIPTION
Hello! Ricently I used this tool under Windows 7 x64, Python 2.7.15 x86_64. There are few fixes I made.

Using OS specific separator instead of `:` will cause misses on old caches. But this does make new caches portable.